### PR TITLE
Move patches from meta arago local repo

### DIFF
--- a/omap_hwspinlock_test.c
+++ b/omap_hwspinlock_test.c
@@ -26,12 +26,12 @@ struct hwspinlock_data {
 	const unsigned int max_locks;
 };
 
-static int hwspin_lock_test(struct hwspinlock *hwlock)
+static int hwspin_lock_test(struct hwspinlock *hwlock, int lock_num)
 {
 	int i;
 	int ret;
 
-	pr_err("\nTesting lock %d\n", hwspin_lock_get_id(hwlock));
+	pr_err("\nTesting lock %d\n", lock_num);
 	for (i = 0; i < count; i++) {
 		ret = hwspin_trylock(hwlock);
 		if (ret) {
@@ -82,7 +82,7 @@ static int hwspin_lock_test_all_locks(unsigned int max_locks)
 			continue;
 		}
 
-		ret1 = hwspin_lock_test(hwlock);
+		ret1 = hwspin_lock_test(hwlock, i);
 		if (ret1) {
 			pr_err("hwspinlock tests failed on lock %d\n", i);
 			ret = ret1;
@@ -147,17 +147,17 @@ static int hwspin_lock_test_all_phandle_locks(unsigned int max_locks)
 			continue;
 		}
 
-		ret1 = hwspin_lock_test(hwlock);
+		ret1 = hwspin_lock_test(hwlock, i);
 		if (ret1) {
 			pr_err("hwspinlock test failed on DT lock %d, ret = %d\n",
-			       hwspin_lock_get_id(hwlock), ret1);
+			       hwlock_id, ret1);
 			ret = ret1;
 		}
 
 		ret1 = hwspin_lock_free(hwlock);
 		if (ret1) {
 			pr_err("hwspin_lock_free failed on lock %d\n",
-			       hwspin_lock_get_id(hwlock));
+			       hwlock_id);
 			ret = ret1;
 		}
 	}

--- a/omap_hwspinlock_test.c
+++ b/omap_hwspinlock_test.c
@@ -199,6 +199,10 @@ static const struct hwspinlock_data soc_data[] = {
 	{ "ti,j7200",	256, },
 	{ "ti,am642",	256, },
 	{ "ti,j721s2",	256, },
+	{ "ti,am625",	256, },
+	{ "ti,am6254xxl",	256, },
+	{ "ti,am62a7",	256, },
+	{ "ti,am62p5",	256, },
 	{ /* sentinel */ },
 };
 


### PR DESCRIPTION
This adds two patches from meta arago to local repo.

1. Support for AM62 SoC's
2. Fix for The hwspin_lock_get_id() function which was recently removed from Linux kernel