### PR TITLE
Add support for J722S SoC

### DIFF
--- a/omap_hwspinlock_test.c
+++ b/omap_hwspinlock_test.c
@@ -203,6 +203,7 @@ static const struct hwspinlock_data soc_data[] = {
 	{ "ti,am6254xxl",	256, },
 	{ "ti,am62a7",	256, },
 	{ "ti,am62p5",	256, },
+	{ "ti,j722s",	256, },
 	{ /* sentinel */ },
 };
 


### PR DESCRIPTION
The K3 J722s SoC has a hwspinlock IP in MAIN domain, same as AM62P SoC.
Extend the test to add the desired SoC compatible so that the test can be exercised on this SoC.